### PR TITLE
Support upload_tmp_dir value when importing CSV

### DIFF
--- a/src/Model/ResourceModel/Carrier/Matrixrate.php
+++ b/src/Model/ResourceModel/Carrier/Matrixrate.php
@@ -145,6 +145,11 @@ class Matrixrate extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
     protected $_filesystem;
 
     /**
+     * @var \Magento\Framework\Filesystem\Directory\ReadFactory
+     */
+    private $_readFactory;
+
+    /**
      * @param \Magento\Framework\Model\ResourceModel\Db\Context $context
      * @param \Psr\Log\LoggerInterface $logger
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $coreConfig
@@ -152,7 +157,7 @@ class Matrixrate extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
      * @param \WebShopApps\MatrixRate\Model\Carrier\Matrixrate $carrierMatrixrate
      * @param \Magento\Directory\Model\ResourceModel\Country\CollectionFactory $countryCollectionFactory
      * @param \Magento\Directory\Model\ResourceModel\Region\CollectionFactory $regionCollectionFactory
-     * @param \Magento\Framework\Filesystem $filesystem
+     * @param \Magento\Framework\Filesystem\Directory\ReadFactory $readFactory
      * @param string|null $resourcePrefix
      */
     public function __construct(
@@ -163,7 +168,7 @@ class Matrixrate extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
         \WebShopApps\MatrixRate\Model\Carrier\Matrixrate $carrierMatrixrate,
         \Magento\Directory\Model\ResourceModel\Country\CollectionFactory $countryCollectionFactory,
         \Magento\Directory\Model\ResourceModel\Region\CollectionFactory $regionCollectionFactory,
-        \Magento\Framework\Filesystem $filesystem,
+        \Magento\Framework\Filesystem\Directory\ReadFactory $readFactory,
         $resourcePrefix = null
     ) {
         parent::__construct($context, $resourcePrefix);
@@ -173,7 +178,7 @@ class Matrixrate extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
         $this->_carrierMatrixrate = $carrierMatrixrate;
         $this->_countryCollectionFactory = $countryCollectionFactory;
         $this->_regionCollectionFactory = $regionCollectionFactory;
-        $this->_filesystem = $filesystem;
+        $this->_readFactory = $readFactory;
     }
 
     /**
@@ -329,9 +334,9 @@ class Matrixrate extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
         $this->_importErrors = [];
         $this->_importedRows = 0;
 
-        $tmpDirectory = $this->_filesystem->getDirectoryRead(DirectoryList::SYS_TMP);
-        $path = $tmpDirectory->getRelativePath($csvFile);
-        $stream = $tmpDirectory->openFile($path);
+        $uploadDirectory = $this->_readFactory->create(ini_get('upload_tmp_dir') ?: sys_get_temp_dir());
+        $path = $uploadDirectory->getRelativePath($csvFile);
+        $stream = $uploadDirectory->openFile($path);
 
         // check and skip headers
         $headers = $stream->readCsv();


### PR DESCRIPTION
Previously the upload handler for the matrix was always assuming that files are
uploaded to the system's temp directory, but this is isn't always the case. If
the PHP ini is configured with a value in upload_tmp_dir then this will break
the matrix import.

This fixes #7 