### PR TITLE
Support rate exclusions via negative shipping price

### DIFF
--- a/src/Model/Carrier/Matrixrate.php
+++ b/src/Model/Carrier/Matrixrate.php
@@ -183,7 +183,13 @@ class Matrixrate extends \Magento\Shipping\Model\Carrier\AbstractCarrier impleme
 
         $foundRates = false;
 
+        $excludedDeliveries = [];
         foreach ($rateArray as $rate) {
+            if ($rate['price'] < 0) {
+                $excludedDeliveries[] = $rate['shipping_method'];
+                continue;
+            }
+
             if (!empty($rate) && $rate['price'] >= 0) {
                 /** @var \Magento\Quote\Model\Quote\Address\RateResult\Method $method */
                 $method = $this->_resultMethodFactory->create();
@@ -205,6 +211,16 @@ class Matrixrate extends \Magento\Shipping\Model\Carrier\AbstractCarrier impleme
 
                 $result->append($method);
                 $foundRates = true; // have found some valid rates
+            }
+        }
+
+        if (!empty($excludedDeliveries)) {
+            $allRates = $result->getAllRates();
+            $result = $this->_rateResultFactory->create();
+            foreach ($allRates as $method) {
+                if (!in_array($method->getMethodTitle(), $excludedDeliveries)) {
+                    $result->append($method);
+                }
             }
         }
 

--- a/src/Model/ResourceModel/Carrier/Matrixrate.php
+++ b/src/Model/ResourceModel/Carrier/Matrixrate.php
@@ -654,10 +654,7 @@ class Matrixrate extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
         if (!is_numeric($value)) {
             return false;
         }
-        $value = (double)sprintf('%.4F', $value);
-        if ($value < 0.0000) {
-            return false;
-        }
-        return $value;
+
+        return (double)sprintf('%.4F', $value);
     }
 }


### PR DESCRIPTION
This introduces support for adding a row in the matrix that marks a rate as
excluded for a specific postcode. This functionality was part of the Magento
1.x module but not part of the 2.x module.