### PR TITLE
Rate code changed to be consistent across multipel request with same …

### DIFF
--- a/src/Model/Carrier/Matrixrate.php
+++ b/src/Model/Carrier/Matrixrate.php
@@ -191,7 +191,7 @@ class Matrixrate extends \Magento\Shipping\Model\Carrier\AbstractCarrier impleme
                 $method->setCarrier('matrixrate');
                 $method->setCarrierTitle($this->getConfigData('title'));
 
-                $method->setMethod('matrixrate_' . $rate['pk']);
+                $method->setMethod('matrixrate_' . $rate['dest_country_id'].($rate['price']*100));
                 $method->setMethodTitle(__($rate['shipping_method']));
 
                 if ($request->getFreeShipping() === true || $request->getPackageQty() == $freeQty) {


### PR DESCRIPTION
…request data

Rate code needs to be consistent accross all request to rates with same request data. 

Depending on $rate['pk']  can't be used. Cause pk (primary key) can change during requests while rates are deleted and requested again. primary key is not a warranted value and depends on rates being available for request across all available methods (more methods more keys etc)

to illustrate this then at one reload your rate code can be matrixrate_matrixrate_344 and on another reload the same rate can get a different code matrixrate_matrixrate_244 etc and it won't survive quote validation cause rate code is not the same for same rate request data and user will get a error reporting to select a shipping method

rate deletion is built in to magento totals collection flow, see  Magento\Quote\Model\Quote\Address::collectShippingRates() method for details.

This change changes the code do be dependant on rate data instead of random key in database and rate code is unique per requested country + price offered (multiplied by 100) 

to illustrate this:
* rate code for Finland with price 19.00 will become matrixrate_matrixrate_FI1900 
* rate code for USA with price 19.00 will become matrixrate_matrixrate_US1900 