### PR TITLE
condition_from_value set as valid value

### DIFF
--- a/src/Model/ResourceModel/Carrier/Matrixrate.php
+++ b/src/Model/ResourceModel/Carrier/Matrixrate.php
@@ -288,7 +288,7 @@ class Matrixrate extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
             $bind[':condition_value'] = $request->getData($request->getConditionMRName());
 
             $select->where('condition_name = :condition_name');
-            $select->where('condition_from_value < :condition_value');
+            $select->where('condition_from_value <= :condition_value');
             $select->where('condition_to_value >= :condition_value');
 
             $this->logger->debug('SQL Select: ', $select->getPart('where'));


### PR DESCRIPTION
The condition_from_value was not used as a valid value.
When you had a rate from 0 to 5
Then 0 wasn't valid, but 5 was. (Making products with a price of 0, not have this rate available)