### PR TITLE
Trim postcode of whitespaces for rate calculation

### DIFF
--- a/src/Model/ResourceModel/Carrier/Matrixrate.php
+++ b/src/Model/ResourceModel/Carrier/Matrixrate.php
@@ -202,7 +202,7 @@ class Matrixrate extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
     {
         $adapter = $this->getConnection();
         $shippingData=[];
-        $postcode = $request->getDestPostcode();
+        $postcode = trim($request->getDestPostcode());
         if ($zipRangeSet && is_numeric($postcode)) {
             #  Want to search for postcodes within a range
             $zipSearchString = ' AND :postcode BETWEEN dest_zip AND dest_zip_to ';
@@ -228,7 +228,7 @@ class Matrixrate extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
                         ':country_id' => $request->getDestCountryId(),
                         ':region_id' => (int)$request->getDestRegionId(),
                         ':city' => $request->getDestCity(),
-                        ':postcode' => $request->getDestPostcode(),
+                        ':postcode' => trim($request->getDestPostcode()),
                     ];
                     break;
                 case 1: // country, region, no city, postcode
@@ -237,7 +237,7 @@ class Matrixrate extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
                     $bind = [
                         ':country_id' => $request->getDestCountryId(),
                         ':region_id' => (int)$request->getDestRegionId(),
-                        ':postcode' => $request->getDestPostcode(),
+                        ':postcode' => trim($request->getDestPostcode()),
                     ];
                     break;
                 case 2: // country, state, city, no postcode
@@ -260,7 +260,7 @@ class Matrixrate extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
                         .$zipSearchString;
                     $bind = [
                         ':country_id' => $request->getDestCountryId(),
-                        ':postcode' => $request->getDestPostcode(),
+                        ':postcode' => trim($request->getDestPostcode()),
                     ];
                     break;
                 case 5: // country, region


### PR DESCRIPTION
This commit trims the postcode request data of whitespaces to prevent customers from bypassing additional surcharges at basket and/or checkout.