### PR TITLE
Support free shipping modes

### DIFF
--- a/src/Model/Carrier/Matrixrate.php
+++ b/src/Model/Carrier/Matrixrate.php
@@ -213,6 +213,7 @@ class Matrixrate extends \Magento\Shipping\Model\Carrier\AbstractCarrier impleme
                 ]
             );
             $result->append($error);
+            return $result;
         }
 
         // Handle free shipping

--- a/src/Model/Carrier/Matrixrate.php
+++ b/src/Model/Carrier/Matrixrate.php
@@ -221,7 +221,10 @@ class Matrixrate extends \Magento\Shipping\Model\Carrier\AbstractCarrier impleme
 
             switch ($freeShippingMode) {
                 case FreeShippingMode::MODE_CHEAPEST:
-                    $result->getCheapestRate()->setPrice(0);
+                    $cheapestRate = $result->getCheapestRate();
+                    if ($cheapestRate !== null) {
+                        $cheapestRate->setPrice(0);
+                    }
                     break;
                 case FreeShippingMode::MODE_ALL:
                     foreach ($result->getAllRates() as $rate) {

--- a/src/Model/Config/Source/FreeShippingMode.php
+++ b/src/Model/Config/Source/FreeShippingMode.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace WebShopApps\MatrixRate\Model\Config\Source;
+
+class FreeShippingMode implements \Magento\Framework\Data\OptionSourceInterface
+{
+    const MODE_ALL = 'all';
+    const MODE_CHEAPEST = 'cheapest';
+
+    public function toOptionArray()
+    {
+        return [
+            [
+                'value' => self::MODE_ALL,
+                'label' => __('All'),
+            ],
+            [
+                'value' => self::MODE_CHEAPEST,
+                'label' => __('Cheapest only'),
+            ]
+        ];
+    }
+}

--- a/src/etc/adminhtml/system.xml
+++ b/src/etc/adminhtml/system.xml
@@ -106,6 +106,11 @@
                     <label>Sort Order</label>
                 </field>
 
+                <field id="free_shipping_mode" translate="label" type="select" sortOrder="200" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <label>Free shipping mode</label>
+                    <source_model>WebShopApps\MatrixRate\Model\Config\Source\FreeShippingMode</source_model>
+                    <can_be_empty>0</can_be_empty>
+                </field>
             </group>
         </section>
     </system>

--- a/src/etc/config.xml
+++ b/src/etc/config.xml
@@ -46,6 +46,7 @@
                 <title>Select Shipping Method</title>
                 <specificerrmsg>This shipping method is not available. To use this shipping method, please contact us.</specificerrmsg>
                 <handling_type>F</handling_type>
+                <free_shipping_mode>all</free_shipping_mode>
             </matrixrate>
         </carriers>
     </default>


### PR DESCRIPTION
Adding support to give free shipping via cart rules only to the cheapest method. This allows customers to pay extra if they want an expedited shipment option.

The change also allows developers to create their own free shipping mode by creating plugins to the `FreeShippingMode::toOptionArray` and `Matrixrate::collectTotals` methods, as the previous code was setting all prices as zero.

The configuration defaults to `all`, so it will have the same behavior as before.