### PR TITLE
Add null coalescing operator for php8.1 compatibility

### DIFF
--- a/src/Model/ResourceModel/Carrier/Matrixrate.php
+++ b/src/Model/ResourceModel/Carrier/Matrixrate.php
@@ -204,7 +204,7 @@ class Matrixrate extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
     {
         $adapter = $this->getConnection();
         $shippingData=[];
-        $postcode = trim($request->getDestPostcode()); //SHQ18-1978
+        $postcode = trim($request->getDestPostcode() ?? ""); //SHQ18-1978
         if ($zipRangeSet && is_numeric($postcode)) {
             #  Want to search for postcodes within a range. SHQ18-98 Can't use bind. Will convert int to string
             $zipSearchString = ' AND ' . (int)$postcode . ' BETWEEN dest_zip AND dest_zip_to ';


### PR DESCRIPTION
Due to the core RateRequest::getDestPostcode() function returning null in some circumstances this ensures a php8.1 compatible value is supplied to the trim function.