### PR TITLE
Change the boundary checks when the condition value is exactly 0 

### DIFF
--- a/src/Model/ResourceModel/Carrier/Matrixrate.php
+++ b/src/Model/ResourceModel/Carrier/Matrixrate.php
@@ -305,8 +305,14 @@ class Matrixrate extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
             $bind[':condition_value'] = $condition;
 
             $select->where('condition_name = :condition_name');
-            $select->where('condition_from_value < :condition_value');
-            $select->where('condition_to_value >= :condition_value');
+
+            if ($condition === 0) {
+                $select->where('condition_from_value = :condition_value');
+                $select->where('condition_to_value > :condition_value');
+            } else {
+                $select->where('condition_from_value < :condition_value');
+                $select->where('condition_to_value >= :condition_value');
+            }
 
             $this->logger->debug('SQL Select: ', $select->getPart('where'));
             $this->logger->debug('Bindings: ', $bind);


### PR DESCRIPTION
When working with free shipping scenarios, the package weight and values get set to 0.

The way Matrixrates is checking for rates only matches on strict "lower than" which will never match a vlaue of 0 (as there are no negative wegihts or values).

This PR treats the condition value of 0 as an exception to change how the rate boundaries are checked against