### PR TITLE
Updates logic to get shipping rates

### DIFF
--- a/src/Model/Carrier/Matrixrate.php
+++ b/src/Model/Carrier/Matrixrate.php
@@ -179,6 +179,11 @@ class Matrixrate extends \Magento\Shipping\Model\Carrier\AbstractCarrier impleme
         $request->setPackageWeight($oldWeight);
         $request->setPackageQty($oldQty);
 
+        //Accounts for no free shipping rate available in webshopapps_matrix table
+        if (empty($rateArray)) {
+            $rateArray = $this->getRate($request, $zipRange);
+        }
+
         $foundRates = false;
 
         foreach ($rateArray as $rate) {


### PR DESCRIPTION
Fix for bug where the getFreeMethodWeight() function is dependent on a value other than null is being returned to build the shipping rate array. 

Use Case:

On Magento stores, applying a coupon that has a fixed discount for both the subtotal and shipping cost will throw an error for shipping total when the ratesArray is empty. This is inevitable when getFreeMethodWeight() returns null.

![Screenshot 2024-05-14 at 3 41 56 PM](https://github.com/webshopapps/module-matrixrate/assets/36486254/717ad447-4d3f-4d71-9769-539c4d28fd00)