### PR TITLE
Fixed an issue where shipping method is not displayed when the postal code contains a space

### DIFF
--- a/src/Model/ResourceModel/Carrier/Matrixrate.php
+++ b/src/Model/ResourceModel/Carrier/Matrixrate.php
@@ -212,6 +212,10 @@ class Matrixrate extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
             $postcode = trim(str_replace("-","", $postcode));
         }
 
+        if (strpos($postcode, ' ') !== false) {
+            $postcode = str_replace(" ", "", $postcode);
+        }
+
         if ($zipRangeSet && is_numeric($postcode)) {
             #  Want to search for postcodes within a range. SHQ18-98 Can't use bind. Will convert int to string
             $zipSearchString = ' AND ' . (int)$postcode . ' BETWEEN dest_zip AND dest_zip_to ';


### PR DESCRIPTION
### Fixed Issues
Fixes : Shipping method is not displayed when the postal code contains a space
(https://github.com/webshopapps/module-matrixrate/issues/142) 

### Description (*)

In countries where postal codes contain a space, such as Sweden (e.g., 100 00) etc, the shipping method is not displayed when the postal code is entered in its correct spaced format